### PR TITLE
Allow RAMCloud to be built and run locally without nfapp.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+RAMCloud
+config
+!config/make-ramcloud

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 RAMCloud
+RAMCloud-install

--- a/config/Dockerfile
+++ b/config/Dockerfile
@@ -1,0 +1,40 @@
+# Install the dependencies required to build RAMCloud. This is used as the development environment.
+FROM debian:buster as dev
+RUN apt-get update \
+ && apt-get install --yes \
+      build-essential \
+      g++ \
+      git \
+      libboost-dev \
+      libboost-filesystem-dev \
+      libboost-program-options-dev \
+      libboost-system-dev \
+      libibverbs-dev \
+      libpcre++-dev \
+      libssl-dev \
+      libzookeeper-mt-dev \
+      protobuf-compiler \
+      stgit \
+ && rm -rf /var/lib/apt/lists/*
+ENV INSTALL_DIR=/tmp/RAMCloud-install
+
+# Build RAMCloud from the patched source code.
+FROM dev as build
+COPY . /src
+WORKDIR /src
+RUN ./patch && ./config/make-ramcloud
+
+# Copy the build artifacts from the build image and only install the runtime dependencies for RAMCloud.
+FROM debian:buster
+RUN apt-get update \
+ && apt-get install --yes \
+      libboost-filesystem1.67.0 \
+      libboost-program-options1.67 \
+      libboost-system1.67.0 \
+      libibverbs1 \
+      libpcrecpp0v5 \
+      libprotobuf17 \
+      libssl1.1 \
+      libzookeeper-mt2 \
+ && rm -rf /var/lib/apt/lists/*
+COPY --from=build /tmp/RAMCloud-install /usr/local

--- a/config/Dockerfile.local
+++ b/config/Dockerfile.local
@@ -1,0 +1,16 @@
+# Copy the RAMCloud install files in the RAMCloud-install directory. This allows us to make containers from local
+# incremental builds rather than having to build RAMCloud from scratch each time. It should make the development cycle
+# substantially shorter.
+FROM debian:buster as RAMCloud-local
+RUN apt-get update \
+ && apt-get install --yes \
+      libboost-filesystem1.67.0 \
+      libboost-program-options1.67 \
+      libboost-system1.67.0 \
+      libibverbs1 \
+      libpcrecpp0v5 \
+      libprotobuf17 \
+      libssl1.1 \
+      libzookeeper-mt2 \
+ && rm -rf /var/lib/apt/lists/*
+COPY ./RAMCloud-install /usr/local

--- a/config/dev-env
+++ b/config/dev-env
@@ -1,0 +1,14 @@
+#!/bin/bash -e
+PROJECT_SRC="$(readlink -f "$(dirname "$0")/..")"
+cd "${PROJECT_SRC}"
+mkdir -p RAMCloud-install
+docker build . -f config/Dockerfile --target=dev -t ramcloud-dev-env
+docker run \
+  --interactive \
+  --tty \
+  --rm \
+  --volume "$(pwd):/src:rw" \
+  --volume "$(pwd)/RAMCloud-install:/tmp/RAMCloud-install" \
+  --workdir /src \
+  --hostname ramcloud-dev-env \
+  ramcloud-dev-env

--- a/config/docker-compose.yml
+++ b/config/docker-compose.yml
@@ -1,0 +1,100 @@
+version: '3.1'
+services:
+  zookeeper-1:
+    image: zookeeper
+    restart: always
+    hostname: zookeeper-1
+    ports:
+      - 2181:2181
+    environment:
+      ZOO_MY_ID: 1
+      ZOO_SERVERS: server.1=0.0.0.0:2888:3888;2181 server.2=zookeeper-2:2888:3888;2181 server.3=zookeeper-3:2888:3888;2181
+    networks:
+      ramcloud-test:
+        ipv4_address: 10.0.1.1
+  zookeeper-2:
+    image: zookeeper
+    restart: always
+    hostname: zookeeper-2
+    ports:
+      - 2182:2181
+    environment:
+      ZOO_MY_ID: 2
+      ZOO_SERVERS: server.1=zookeeper-1:2888:3888;2181 server.2=0.0.0.0:2888:3888;2181 server.3=zookeeper-3:2888:3888;2181
+    networks:
+      ramcloud-test:
+        ipv4_address: 10.0.1.2
+  zookeeper-3:
+    image: zookeeper
+    restart: always
+    hostname: zookeeper-3
+    ports:
+      - 2183:2181
+    environment:
+      ZOO_MY_ID: 3
+      ZOO_SERVERS: server.1=zookeeper-1:2888:3888;2181 server.2=zookeeper-2:2888:3888;2181 server.3=0.0.0.0:2888:3888;2181
+    networks:
+      ramcloud-test:
+        ipv4_address: 10.0.1.3
+  rc-coordinator-1:
+    build:
+      context: ../
+      dockerfile: "config/Dockerfile${RAMCLOUD_DOCKERFILE_EXTENSION:-.local}"
+    command: bash -c "sleep 10 && rc-coordinator --externalStorage zk:zookeeper-1:2181,zookeeper-2:2181,zookeeper-3:2181 --coordinator basic+udp:host=10.0.2.1,port=11111 --clusterName main"
+    networks:
+      ramcloud-test:
+        ipv4_address: 10.0.2.1
+  rc-coordinator-2:
+    build:
+      context: ../
+      dockerfile: "config/Dockerfile${RAMCLOUD_DOCKERFILE_EXTENSION:-.local}"
+    command: bash -c "sleep 10 && rc-coordinator --externalStorage zk:zookeeper-1:2181,zookeeper-2:2181,zookeeper-3:2181 --coordinator basic+udp:host=10.0.2.2,port=11111 --clusterName main"
+    networks:
+      ramcloud-test:
+        ipv4_address: 10.0.2.2
+  rc-coordinator-3:
+    build:
+      context: ../
+      dockerfile: "config/Dockerfile${RAMCLOUD_DOCKERFILE_EXTENSION:-.local}"
+    command: bash -c "sleep 10 && rc-coordinator --externalStorage zk:zookeeper-1:2181,zookeeper-2:2181,zookeeper-3:2181 --coordinator basic+udp:host=10.0.2.3,port=11111 --clusterName main"
+    networks:
+      ramcloud-test:
+        ipv4_address: 10.0.2.3
+  rc-server-1:
+    build:
+      context: ../
+      dockerfile: "config/Dockerfile${RAMCLOUD_DOCKERFILE_EXTENSION:-.local}"
+    command: bash -c "sleep 20 && rc-server --externalStorage zk:zookeeper-1:2181,zookeeper-2:2181,zookeeper-3:2181 --local basic+udp:host=10.0.3.1,port=11112 --clusterName main"
+    networks:
+      ramcloud-test:
+        ipv4_address: 10.0.3.1
+  rc-server-2:
+    build:
+      context: ../
+      dockerfile: "config/Dockerfile${RAMCLOUD_DOCKERFILE_EXTENSION:-.local}"
+    command: bash -c "sleep 20 && rc-server --externalStorage zk:zookeeper-1:2181,zookeeper-2:2181,zookeeper-3:2181 --local basic+udp:host=10.0.3.2,port=11112 --clusterName main"
+    networks:
+      ramcloud-test:
+        ipv4_address: 10.0.3.2
+  rc-server-3:
+    build:
+      context: ../
+      dockerfile: "config/Dockerfile${RAMCLOUD_DOCKERFILE_EXTENSION:-.local}"
+    command: bash -c "sleep 20 && rc-server --externalStorage zk:zookeeper-1:2181,zookeeper-2:2181,zookeeper-3:2181 --local basic+udp:host=10.0.3.3,port=11112 --clusterName main"
+    networks:
+      ramcloud-test:
+        ipv4_address: 10.0.3.3
+  rc-client-1:
+    build:
+      context: ../
+      dockerfile: "config/Dockerfile${RAMCLOUD_DOCKERFILE_EXTENSION:-.local}"
+    command: bash -c "sleep 30 && rc-client --externalStorage zk:zookeeper-1:2181,zookeeper-2:2181,zookeeper-3:2181 --clusterName main"
+    networks:
+      ramcloud-test:
+        ipv4_address: 10.0.4.1
+networks:
+  ramcloud-test:
+    ipam:
+      driver: default
+      config:
+        - subnet: 10.0.0.0/16

--- a/config/make-container
+++ b/config/make-container
@@ -1,0 +1,27 @@
+#!/bin/bash -e
+
+PROJECT_SRC="$(readlink -f "$(dirname "$0")/..")"
+cd "${PROJECT_SRC}"
+
+LOCAL=false
+while [[ ${#} -gt 0 ]]; do
+  KEY="${1}"
+  case ${KEY} in
+    --local)
+      LOCAL=true
+      shift
+      ;;
+    *)
+      echo "Unrecognized option: ${KEY}"
+      exit 1
+      ;;
+  esac
+done
+
+if [[ "${LOCAL}" == true ]]; then
+  DOCKERFILE="Dockerfile.local"
+else
+  DOCKERFILE="Dockerfile"
+fi
+
+docker build . -f "config/${DOCKERFILE}" --tag ramcloud-test

--- a/config/make-ramcloud
+++ b/config/make-ramcloud
@@ -1,0 +1,13 @@
+#/bin/bash -ex
+
+cd "/src/RAMCloud"
+rm -rf "${INSTALL_DIR}"/*
+make -j$(nproc) install DEBUG=no GLIBCXX_USE_CXX11_ABI=yes EXTRACXXFLAGS='-Wno-error'
+
+# Rename the binaries to something a little more descriptive.
+mv "${INSTALL_DIR}/bin/coordinator" "${INSTALL_DIR}/bin/rc-coordinator"
+mv "${INSTALL_DIR}/bin/client"      "${INSTALL_DIR}/bin/rc-client"
+mv "${INSTALL_DIR}/bin/server"      "${INSTALL_DIR}/bin/rc-server"
+
+# Move the libraries to the correct place instead of in the ramcloud subdirectory.
+mv ${INSTALL_DIR}/lib/ramcloud/* ${INSTALL_DIR}/lib && rmdir ${INSTALL_DIR}/lib/ramcloud


### PR DESCRIPTION
This is to allow RAMCloud to be tested and developed in isolation from nfapp. The containers are `FROM debian:buster` right now because I don't have the time to make a new `stateless-base` image adding the required boost packages (I avoid building boost from source here, unlike nfapp). It's probably fine to keep this on `debian:buster` since these containers are not currently meant to be deployed to a cluster, they're just for local testing.