### PR TITLE
Modifies MakefragTest so that unit tests for RAMCloud can be ran.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 RAMCloud
 RAMCloud-install
+.vscode

--- a/README.md
+++ b/README.md
@@ -36,9 +36,15 @@ with the following command run in the development environment shell:
     ./config/make-ramcloud
 
 This will place all of the RAMCloud build artifacts at `./RAMCloud-install`.
-After RAMCloud has been built, a local cluster can be built using the commands
-from the repository root on your host machine, i.e. _not_ in the development
-environment container:
+
+(Optional) One other thing you can do within this development environment shell 
+is run the unit tests for RAMCloud. You can do this with:
+
+    ./config/make-ramcloud-test
+
+After RAMCloud has been built (via make-ramcloud), a local cluster can be built
+using the commands from the repository root on your host machine, i.e. _not_ in
+the development environment container:
 
     cd ./config
     docker-compose up --build --detach
@@ -125,6 +131,13 @@ the files in the RAMCloud directory and rerun `./config/make-ramcloud` to
 perform an incremental build. If you need to make a clean build you can just
 delete the RAMCloud directory and the contents of the RAMCloud-install directory
 and run the above commands again to rebuild it.
+
+# Debugging
+
+On your host machine (i.e., not the development environment container), it will
+help to modify the kernel.core_pattern in your /etc/sysctl.conf file. See 
+`http://man7.org/linux/man-pages/man5/core.5.html` for more information on how 
+the different values work, and the `%` placeholders.
 
 # Containers
 

--- a/config/Dockerfile
+++ b/config/Dockerfile
@@ -4,6 +4,7 @@ RUN apt-get update \
  && apt-get install --yes \
       build-essential \
       g++ \
+      gdb \
       git \
       libboost-dev \
       libboost-filesystem-dev \

--- a/config/make-ramcloud-test
+++ b/config/make-ramcloud-test
@@ -1,0 +1,4 @@
+#/bin/bash -ex
+
+cd "/src/RAMCloud"
+make -j$(nproc) test DEBUG=yes GLIBCXX_USE_CXX11_ABI=yes EXTRACXXFLAGS='-Wno-error'

--- a/patches/make-rc-unit-test.patch
+++ b/patches/make-rc-unit-test.patch
@@ -1,0 +1,34 @@
+Modifies RAMCloud MakefragTest so that unit tests can be ran. (There is still flakiness to debug)
+
+From: Ofer Gill <ofer.gill@stateless.net>
+
+
+---
+ src/MakefragTest |    8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/src/MakefragTest b/src/MakefragTest
+index 69c0e1cf..36926242 100644
+--- a/src/MakefragTest
++++ b/src/MakefragTest
+@@ -273,14 +273,18 @@ else
+ GLIBCXX_ABI := -D_GLIBCXX_USE_CXX11_ABI=0
+ endif
+ 
++# Directory for installation: various subdirectories such as include and
++# bin will be created by "make install".
++INSTALL_DIR ?= install
++
+ # The following target tries to compile a simple RAMCloud client app using
+ # only installed files, in order to ensure that "make install" has pulled
+ # together all the information needed by client apps. Note: this target
+ # does *not* use the normal compilation flags, since we only want installed
+ # info to be available.
+ testInstall: install
+-	$(CXX) --std=$(CXX_STANDARD) $(GLIBCXX_ABI) -g -DNDEBUG -Iinstall/include -I. \
+-	        src/TestClient.cc -o $(OBJDIR)/TestClient -Linstall/lib/ramcloud/ \
++	$(CXX) --std=$(CXX_STANDARD) $(GLIBCXX_ABI) -g -DTESTING=1 -fno-builtin -I$(INSTALL_DIR)/include -I. \
++	        src/TestClient.cc -o $(OBJDIR)/TestClient -L$(INSTALL_DIR)/lib/ramcloud/ \
+ 	        -lramcloud -Wl,-rpath=install/bin $(TEST_INSTALL_FLAGS)
+ 
+ TESTS_ONLY_OBJFILES := $(TESTS_SRCFILES)

--- a/patches/series
+++ b/patches/series
@@ -4,3 +4,4 @@ fix-dpdk-mbuf-release.patch
 dpdk-config.patch
 multiop-includes.patch
 remove-java.patch
+make-rc-unit-test.patch


### PR DESCRIPTION
Also adds make-ramcloud-test script for dev env shell.
There's still test flakiness to resolve in follow-up PR.