### PR TITLE
Update DPDK fix to include newly introduced bugs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,19 @@ reordering patches, rebasing onto newer upstream changes, and other operations
 are explained in the
 [stgit tutorial](http://procode.org/stgit/doc/tutorial.html).
 
+# Updating Existing Patches
+
+If you want to change an existing patch, first retreive the fully patched code.
+After you have the code, from the _inner_ `RAMCloud` directory you can use the
+command `stg series` to show all patches in the series. Find the patch you want
+to edit and use the command `stg goto ${patch}` where `${patch}` is the name of
+the patch to be edited. From there, edit the code as needed. Once all edits are
+made, use `stg refresh` to add the working changes to the patch. Once the patch
+is updated, go back to the last patch in the series using the command
+`stg goto $(stg series | tail -1 | cut -c2-)` (there may be an easier command to
+do that, but this one works). Finally, once you are back at the top of the stack
+of patches, you can use `stg export -d ../` to export the updated patch.
+
 # Incremental Development
 
 To enter a development environment issue the following command from the

--- a/patches/dpdk-config.patch
+++ b/patches/dpdk-config.patch
@@ -25,7 +25,7 @@ to run sockets that are not socket zero.
  5 files changed, 133 insertions(+), 34 deletions(-)
 
 diff --git a/src/DpdkDriver.cc b/src/DpdkDriver.cc
-index 7aa51492..77c5808c 100644
+index af56e8e5..3f5e9719 100644
 --- a/src/DpdkDriver.cc
 +++ b/src/DpdkDriver.cc
 @@ -89,6 +89,7 @@ DpdkDriver::DpdkDriver()

--- a/patches/fix-dpdk-mbuf-release.patch
+++ b/patches/fix-dpdk-mbuf-release.patch
@@ -6,11 +6,11 @@ The payload_to_mbuf macro in DpdkDriver.cc is off by four because it fails to
 account for the VLAN tag in the ethernet header. The error results in undefined
 behvior when freeing DPDK buffers.
 ---
- src/DpdkDriver.cc |    2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
+ src/DpdkDriver.cc |    6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/src/DpdkDriver.cc b/src/DpdkDriver.cc
-index 39fec055..7aa51492 100644
+index 39fec055..af56e8e5 100644
 --- a/src/DpdkDriver.cc
 +++ b/src/DpdkDriver.cc
 @@ -71,7 +71,7 @@ namespace {
@@ -22,3 +22,14 @@ index 39fec055..7aa51492 100644
  
  constexpr uint16_t DpdkDriver::PRIORITY_TO_PCP[8];
  
+@@ -351,8 +351,8 @@ DpdkDriver::receivePackets(uint32_t maxPackets,
+     for (uint32_t i = 0; i < totalPkts; i++) {
+         struct rte_mbuf* m = mPkts[i];
+         char* data = rte_pktmbuf_mtod(m, char*);
+-        char* payload = data + ETHER_HDR_LEN;
+-        uint32_t length = rte_pktmbuf_pkt_len(m) - ETHER_HDR_LEN;
++        char* payload = data + ETHER_VLAN_HDR_LEN;
++        uint32_t length = rte_pktmbuf_pkt_len(m) - ETHER_VLAN_HDR_LEN;
+         struct ether_hdr* ethHdr = rte_pktmbuf_mtod(m, struct ether_hdr*);
+         assert(ethHdr->ether_type == rte_cpu_to_be_16(
+                 NetUtil::EthPayloadType::RAMCLOUD));


### PR DESCRIPTION
We moved to a newer version of RAMCloud, and that newer version injected additional bugs where they do not account for the VLAN tag on DPDK traffic. Rather than making a new patch I just updated the existing patch that also deals with incorrect mbuf pointers.