### PR TITLE
Makes RAMCloud Fault Tolerant when a server goes down!!!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,4 @@
 RAMCloud
 RAMCloud-install
-.vscode
-tmp
 __pycache__/
 *.py[cod]

--- a/config/supervisord.conf
+++ b/config/supervisord.conf
@@ -10,13 +10,15 @@ stderr_logfile_maxbytes=0
 
 [program:ramcloud-coordinator]
 command=/usr/local/bin/rc-coordinator --externalStorage %(ENV_RC_EXTERNAL_STORAGE)s --clusterName %(ENV_RC_CLUSTER_NAME)s --coordinator basic+udp:host=%(ENV_RC_IP)s,port=11111
+autorestart=false
 stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/fd/2
 stderr_logfile_maxbytes=0
 
 [program:ramcloud-server]
-command=/usr/local/bin/rc-server --externalStorage %(ENV_RC_EXTERNAL_STORAGE)s --clusterName %(ENV_RC_CLUSTER_NAME)s --local basic+udp:host=%(ENV_RC_IP)s,port=11112
+command=/usr/local/bin/rc-server --externalStorage %(ENV_RC_EXTERNAL_STORAGE)s --clusterName %(ENV_RC_CLUSTER_NAME)s --local basic+udp:host=%(ENV_RC_IP)s,port=11112 --replicas 1
+autorestart=false
 stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/fd/2


### PR DESCRIPTION
If replicas isn't explicitly set, it's assume to be zero (i.e. no backups for servers???) So setting this explicitly to 1 to achieve the fault-tolerant effects corresponding to the RAMCloud paper.

7 is the max # of containers to support this behavior on a 401GB HDD with 16GB RAM, so using that for the test. We can figure out how to support more containers later.