### PR TITLE
Enforces 10-minute timeout limit per test.

### DIFF
--- a/config/Pipfile
+++ b/config/Pipfile
@@ -12,6 +12,7 @@ pyexpect = "*"
 grpcio = "*"
 grpcio-tools = "*"
 kazoo = "*"
+timeout-decorator = "*"
 
 [requires]
 python_version = "2.7"

--- a/config/Pipfile.lock
+++ b/config/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "f081b35b3a523bd410b159fc2d6f5932b80f743f340cb39673b42921377226ca"
+            "sha256": "18995646bd2ea2077ca819f672dc5e9fdfef5ec1315c4df8a8b7741346908b3c"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -230,6 +230,13 @@
                 "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
             ],
             "version": "==1.12.0"
+        },
+        "timeout-decorator": {
+            "hashes": [
+                "sha256:1a5e276e75c1c5acbf3cdbd9b5e45d77e1f8626f93e39bd5115d68119171d3c6"
+            ],
+            "index": "pypi",
+            "version": "==0.4.1"
         },
         "urllib3": {
             "hashes": [

--- a/testing/test_cluster.py
+++ b/testing/test_cluster.py
@@ -3,7 +3,10 @@ import ramcloud
 import Table_pb2
 import unittest
 from pyexpect import expect
+from timeout_decorator import timeout
 import cluster_test_utils as ctu
+
+ten_minutes = 600  # number of seconds in 10 minutes
 
 class TestCluster(unittest.TestCase):
     def setUp(self):
@@ -57,6 +60,7 @@ class TestCluster(unittest.TestCase):
         value = self.rc_client.read(self.table, 'testKey')
         expect(value).equals(('testValue', 1))
 
+    @timeout(ten_minutes)
     def test_zookeeper_read(self):
         self.make_cluster(num_nodes=4)
         self.createTestValue()
@@ -71,6 +75,7 @@ class TestCluster(unittest.TestCase):
         expect(table_parsed.id).equals(1L)
         expect(table_parsed.name).equals("test")
 
+    @timeout(ten_minutes)
     def test_read_write(self):
         self.make_cluster(num_nodes=3)
         self.rc_client.create_table('test_table')
@@ -80,6 +85,7 @@ class TestCluster(unittest.TestCase):
 
         expect(value).equals('Hello, World!')
 
+    @timeout(ten_minutes)
     def test_two_writes(self):
         self.make_cluster(num_nodes=4)
         self.rc_client.create_table('test_table')
@@ -91,9 +97,11 @@ class TestCluster(unittest.TestCase):
 
         expect(value).equals('Good weather')
 
+    @timeout(ten_minutes)
     def test_01_simple_recovery_graceful_server_down(self):
         self.simple_recovery(kill_command = 'killall -SIGTERM rc-server')
 
+    @timeout(ten_minutes)
     def test_01_simple_recovery_forced_server_down(self):
         self.simple_recovery(kill_command = 'killall -SIGKILL rc-server')
 


### PR DESCRIPTION
Each test on average runs for 2 minutes, so this limit is reasonable.