### PR TITLE
Adds two new fault tolerance tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ It is easy to use the ZooKeeper CLI to look at the contents of ZooKeeper, which
 is used by RAMCloud to store persistent configuration information. Simply run
 the command
 
-    docker run -it --rm --net ramcloud-net zookeeper zkCli.sh -server zookeeper-1
+    docker run -it --rm --net ramcloud-net zookeeper zkCli.sh -server ramcloud-node-1
 
 The command may be run within the dev-env or on your host, it does not matter.
 


### PR DESCRIPTION
One for killing elected coordinator and trying to read data.
One for trying to "write" after the master server is killed.

I needed to reduce # of clusters to 4 due to this being a
sufficient number for the tests we need, and 7 clusters seems
to trigger the RamCloud C++ RPC timeout bug on 1 of 2 runs of
the integration tests.