### PR TITLE
NF-918 Guard log statements in RpcWrapper from dereferencing null ses…

### DIFF
--- a/patches/rpcwrapper-logging-fix.patch
+++ b/patches/rpcwrapper-logging-fix.patch
@@ -1,0 +1,51 @@
+Guard log statements in RpcWrapper from dereferencing null session pointers
+
+From: nobody <nobody@nowhere>
+
+
+---
+ src/RpcWrapper.cc |   12 +++++++++---
+ 1 file changed, 9 insertions(+), 3 deletions(-)
+
+diff --git a/src/RpcWrapper.cc b/src/RpcWrapper.cc
+index 60b6cb45..fc2c8ff4 100644
+--- a/src/RpcWrapper.cc
++++ b/src/RpcWrapper.cc
+@@ -183,7 +183,7 @@ RpcWrapper::isReady() {
+                     || (responseHeader->status == STATUS_OK)) {
+                 LOG(ERROR, "Response from %s for %s RPC is too short "
+                         "(needed at least %d bytes, got %d)",
+-                        session->serviceLocator.c_str(),
++                        session ? session->serviceLocator.c_str() : "(no session)",
+                         WireFormat::opcodeSymbol(&request),
+                         responseHeaderLength,
+                         downCast<int>(response->size()));
+@@ -192,6 +192,12 @@ RpcWrapper::isReady() {
+             // Extend the response buffer to be at least responseHeaderLength
+             // bytes long.
+             if (response->size() < responseHeaderLength) {
++                LOG(NOTICE, "Response from %s for %s RPC is too short "
++                        "(needed at least %d bytes, got %d) - Extending to required size.",
++                        session ? session->serviceLocator.c_str() : "(no session)",
++                        WireFormat::opcodeSymbol(&request),
++                        responseHeaderLength,
++                        downCast<int>(response->size()));
+                 response->alloc(responseHeaderLength - response->size());
+             }
+         }
+@@ -217,13 +223,13 @@ RpcWrapper::isReady() {
+                 }
+                 RAMCLOUD_CLOG(NOTICE,
+                         "Server %s returned STATUS_RETRY from %s request: %s",
+-                        session->serviceLocator.c_str(),
++                        session ? session->serviceLocator.c_str() : "(no session)",
+                         WireFormat::opcodeSymbol(&request),
+                         message);
+             } else {
+                 RAMCLOUD_CLOG(NOTICE,
+                         "Server %s returned STATUS_RETRY from %s request",
+-                        session->serviceLocator.c_str(),
++                        session ? session->serviceLocator.c_str() : "(no session)",
+                         WireFormat::opcodeSymbol(&request));
+             }
+             retry(retryResponse->minDelayMicros,

--- a/patches/series
+++ b/patches/series
@@ -11,3 +11,4 @@ plus_one.patch
 transport-timeout-interval.patch
 bindings-migration.patch
 log-sse42-status.patch
+rpcwrapper-logging-fix.patch


### PR DESCRIPTION
…sion pointers

Also add a NOTICE log statement in the interesting case where a response is shorter than expected and has to be extended.