### PR TITLE
NF-1329: Adds TableEnumerator and ShortMacros to installed RAMCloud h…

### DIFF
--- a/patches/series
+++ b/patches/series
@@ -12,3 +12,4 @@ transport-timeout-interval.patch
 bindings-migration.patch
 log-sse42-status.patch
 rpcwrapper-logging-fix.patch
+table-enumerator.patch

--- a/patches/table-enumerator.patch
+++ b/patches/table-enumerator.patch
@@ -1,0 +1,24 @@
+Adds TableEnumerator and ShortMacros headers to install area of RAMCloud
+
+From: nobody <nobody@nowhere>
+
+
+---
+ GNUmakefile |    2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/GNUmakefile b/GNUmakefile
+index 201131cc..227237b1 100644
+--- a/GNUmakefile
++++ b/GNUmakefile
+@@ -467,8 +467,10 @@ INSTALL_INCLUDES := \
+     src/ServerIdRpcWrapper.h \
+     src/ServerMetrics.h \
+     src/ServiceMask.h \
++    src/ShortMacros.h \
+     src/SpinLock.h \
+     src/Status.h \
++    src/TableEnumerator.h \
+     src/TestLog.h \
+     src/Transaction.h \
+     src/Transport.h \


### PR DESCRIPTION
…eaders

- kv_ramcloud_connection.cpp in nfapp needs TableEnumerator for sync enumerations
    It's easier than trying to call the RPC API's in RamCloud.h