### PR TITLE
AUE-23: When key doesn't exist, prohibits reject rules specifying ver…

### DIFF
--- a/patches/nonexistant-rr.patch
+++ b/patches/nonexistant-rr.patch
@@ -1,0 +1,22 @@
+Forced nonexistant key to ban reject-rules specifying versionLE or versionNE
+
+From: nobody <nobody@nowhere>
+
+
+---
+ src/ObjectManager.cc |    2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/ObjectManager.cc b/src/ObjectManager.cc
+index 9c2d3b0c..5f4a6e79 100644
+--- a/src/ObjectManager.cc
++++ b/src/ObjectManager.cc
+@@ -2893,7 +2893,7 @@ Status
+ ObjectManager::rejectOperation(const RejectRules* rejectRules, uint64_t version)
+ {
+     if (version == VERSION_NONEXISTENT) {
+-        if (rejectRules->doesntExist)
++        if (rejectRules->doesntExist || rejectRules->versionLeGiven || rejectRules->versionNeGiven)
+             return STATUS_OBJECT_DOESNT_EXIST;
+         return STATUS_OK;
+     }

--- a/patches/series
+++ b/patches/series
@@ -13,3 +13,4 @@ bindings-migration.patch
 log-sse42-status.patch
 rpcwrapper-logging-fix.patch
 table-enumerator.patch
+nonexistant-rr.patch

--- a/testing/ramcloud_test_cluster.py
+++ b/testing/ramcloud_test_cluster.py
@@ -2,17 +2,32 @@ import cluster_test_utils as ctu
 import argparse
 import sys
 
+# If you're trying to make fake data in RAMCloud, this works from Python3 interpreter,
+# assuming you started up the default 3-node test cluster:
+#
+# >>> import ramcloud
+# >>> import cluster_test_utils as ctu
+# >>> rc = ramcloud.RAMCloud()
+# >>> rc.connect('zk:10.0.1.1:2181,10.0.1.2:2181,10.0.1.3:2181', 'main')
+# >>> rc.create_table('test')
+# >>> tid = rc.get_table_id('test')
+# >>> rc.write(tid, 'testKey', 'testValue')
+# >>> rc.read(tid, 'testKey')
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('--action', '-a', metavar='A', type=str, default="status",
-                        help="Defines the action to take: status, reset, start, stop")
+                        help="Defines the action to take: status, reset, log, start, stop")
     parser.add_argument('--nodes', '-n', type=int, default=3,
                         help="Number of zk, rc-coordinator, and rc-server instances to bring up. Only relevant when there's no cluster up yet. Default is 3")
+    parser.add_argument('--path', '-p', type=str, default="/src/tmp",
+                        help="Path to place logs in when action is set to \"log\"")
 
 args = parser.parse_args()
 
 print("action =",args.action)
 print("nodes =",args.nodes)
+print("path =",args.path)
 if (args.action == "start"):
     x = ctu.ClusterTest()
     x.setUp(num_nodes = args.nodes)
@@ -21,6 +36,14 @@ elif (args.action == "status"):
 elif (args.action == "stop"):
     docker_network, docker_containers = ctu.get_status()
     ctu.destroy_network_and_containers(docker_network, docker_containers)
+elif (args.action == "log"):
+    docker_network, docker_containers = ctu.get_status()
+    if (not docker_network or not docker_containers):
+        print("No network or containers currently up to log")
+        exit()
+    ensemble = ctu.get_ensemble(len(docker_containers))
+    ctu.output_logs_detached(docker_containers, args.path)
+    ctu.output_zk_detached(ensemble, args.path)
 elif (args.action == "reset"):
     docker_network, docker_containers = ctu.get_status()
     if (not docker_network):


### PR DESCRIPTION
…sionNE or versionLE

- This breaks changesets for nfapp, since using any old version to update
    a key incorrectly resurrects it from the dead, undoing the hard work
    of the nfapp table cleaner

- Also adds ability to output logs for RAMCloud test cluster, great for debugging