### PR TITLE
AUE-129: Allows IP CIDR and Docker names to be changed at command-line

### DIFF
--- a/testing/ramcloud_test_cluster.py
+++ b/testing/ramcloud_test_cluster.py
@@ -8,26 +8,43 @@ import sys
 # >>> import ramcloud
 # >>> import cluster_test_utils as ctu
 # >>> rc = ramcloud.RAMCloud()
-# >>> rc.connect('zk:10.0.1.1:2181,10.0.1.2:2181,10.0.1.3:2181', 'main')
+# >>> rc.connect('zk:169.254.3.1:2181,169.254.3.2:2181,169.254.3.3:2181', 'main')
 # >>> rc.create_table('test')
 # >>> tid = rc.get_table_id('test')
 # >>> rc.write(tid, 'testKey', 'testValue')
 # >>> rc.read(tid, 'testKey')
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser()
+    # We list all argument default values as part of the "help menu"
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument('--action', '-a', metavar='A', type=str, default="status",
-                        help="Defines the action to take: status, reset, log, start, stop")
+                        help="Defines the action to take, which is one of: status reset log start stop")
     parser.add_argument('--nodes', '-n', type=int, default=3,
-                        help="Number of zk, rc-coordinator, and rc-server instances to bring up. Only relevant when there's no cluster up yet. Default is 3")
+                        help="Number of zk, rc-coordinator, and rc-server instances to bring up. Only relevant when there's no cluster up yet.")
     parser.add_argument('--path', '-p', type=str, default="/src/tmp",
                         help="Path to place logs in when action is set to \"log\"")
+    parser.add_argument('--cidr', '-c', type=str, default="169.254.3.0/24",
+                        help="IPv4 CIDR to use for the docker network, docker nodes, and zk ensemble in the RAMCloud test cluster. "
+                             "NOTE that only CIDR notations of /24 or /16 are supported at the moment in this program.")
+    parser.add_argument('--docker-names', '-d', type=str, default="ramcloud-test,ramcloud-net,ramcloud-node",
+                        help="Three comma-separated names without spaces, corresponding to IMAGE,NETWORK,NODE where: "
+                             "IMAGE is the name of the docker image to either look for or build, "
+                             "NETWORK is the name of the docker network to create (not an IP address), "
+                             "and NODE is the prefix to use for the names of the docker containers corresponding to the nodes, and "
+                             "appears as NODE-1, NODE-2, NODE-3, etc.")
 
 args = parser.parse_args()
 
 print("action =",args.action)
 print("nodes =",args.nodes)
 print("path =",args.path)
+
+ctu.set_cluster_cidr(args.cidr)
+ctu.set_docker_names(args.docker_names)
+
+print("cidr = {}.0/{}".format(ctu.cluster_ip_prefix, ctu.cluster_notation))
+print("docker_names = {},{},{}".format(ctu.docker_image_name, ctu.docker_network_name, ctu.docker_node_prefix))
+
 if (args.action == "start"):
     x = ctu.ClusterTest()
     x.setUp(num_nodes = args.nodes)


### PR DESCRIPTION
- IP CIDR dictates the ip's & cidr for the docker network, each docker node, and the zk ensemble
- Docker names change the image name, network name, and node prefix used when RCTC invokes docker